### PR TITLE
fix: align db metrics with custom registry and add operation labels

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -34,6 +34,11 @@ func main() {
 	log := logger.NewLogger(env)
 	defer func() { _ = log.Sync() }()
 
+	m, err := metrics.NewMetrics(log)
+	if err != nil {
+		log.Fatal("failed_to_init_metrics", zap.Error(err))
+	}
+
 	db, err := sql.Open("postgres", cfg.Database.PostgresURL)
 	if err != nil {
 		log.Fatal("failed_to_open_db", zap.Error(err))
@@ -59,7 +64,7 @@ func main() {
 		log.Fatal("failed_to_init_bot", zap.Error(err))
 	}
 
-	httpSrv := metrics.NewServer(cfg.Server.PrometheusPort, sqlxDB, tg, log)
+	httpSrv := metrics.NewServer(cfg.Server.PrometheusPort, sqlxDB, tg, m, log)
 	go func() {
 		if err := httpSrv.Start(); err != nil {
 			log.Fatal("failed_to_start_http_server", zap.Error(err))

--- a/internal/database/repository/session_repository.go
+++ b/internal/database/repository/session_repository.go
@@ -75,8 +75,8 @@ func (r *SessionRepository) SaveSession(ctx context.Context, userID int64, state
 	_, err = r.db.ExecContext(ctxQ, saveSessionQuery, userID, state, string(raw))
 	dur := time.Since(start).Seconds()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 
 	if dur > slowQueryThreshold.Seconds() {
 		r.logger.Warn("slow_db_query",
@@ -86,7 +86,7 @@ func (r *SessionRepository) SaveSession(ctx context.Context, userID int64, state
 	}
 
 	if err != nil {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		r.logger.Error("save_session_failed", zap.Error(err), zap.Int64("user_id", userID))
 		return fmt.Errorf("save session: %w", err)
 	}
@@ -124,8 +124,8 @@ func (r *SessionRepository) GetSession(ctx context.Context, userID int64) (*mode
 	)
 	dur := time.Since(start).Seconds()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 
 	if dur > slowQueryThreshold.Seconds() {
 		r.logger.Warn("slow_db_query",
@@ -138,7 +138,7 @@ func (r *SessionRepository) GetSession(ctx context.Context, userID int64) (*mode
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		return nil, fmt.Errorf("get session: %w", err)
 	}
 
@@ -174,8 +174,8 @@ func (r *SessionRepository) ClearSession(ctx context.Context, userID int64) erro
 	_, err := r.db.ExecContext(ctxQ, clearSessionQuery, userID)
 	dur := time.Since(start).Seconds()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 
 	if dur > slowQueryThreshold.Seconds() {
 		r.logger.Warn("slow_db_query",
@@ -184,7 +184,7 @@ func (r *SessionRepository) ClearSession(ctx context.Context, userID int64) erro
 		)
 	}
 	if err != nil {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		return fmt.Errorf("clear session: %w", err)
 	}
 	return nil
@@ -206,8 +206,8 @@ func (r *SessionRepository) UpdateSessionState(ctx context.Context, userID int64
 	_, err := r.db.ExecContext(ctxQ, updateSessionStateQuery, userID, newState)
 	dur := time.Since(start).Seconds()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 
 	if dur > slowQueryThreshold.Seconds() {
 		r.logger.Warn("slow_db_query",
@@ -216,7 +216,7 @@ func (r *SessionRepository) UpdateSessionState(ctx context.Context, userID int64
 		)
 	}
 	if err != nil {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		return fmt.Errorf("update session state: %w", err)
 	}
 	return nil

--- a/internal/database/repository/user_repository.go
+++ b/internal/database/repository/user_repository.go
@@ -46,8 +46,8 @@ func (u *UserRepository) CreateUser(ctx context.Context, telegramID int64, usern
 	dur := time.Since(start).Seconds()
 	cancel()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 	if dur > slowQueryThreshold.Seconds() {
 		u.logger.Warn("slow_db_query", zap.String("operation", op), zap.Float64("duration_seconds", dur))
 	}
@@ -57,7 +57,7 @@ func (u *UserRepository) CreateUser(ctx context.Context, telegramID int64, usern
 		return &user, nil
 	}
 	if err != sql.ErrNoRows {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		u.logger.Error("query error", zap.Error(err))
 		return nil, err
 	}
@@ -75,13 +75,13 @@ func (u *UserRepository) CreateUser(ctx context.Context, telegramID int64, usern
 	dur = time.Since(start).Seconds()
 	cancel()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 	if dur > slowQueryThreshold.Seconds() {
 		u.logger.Warn("slow_db_query", zap.String("operation", op), zap.Float64("duration_seconds", dur))
 	}
 	if err != nil {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		u.logger.Error("error creating a user", zap.Error(err))
 		return nil, err
 	}
@@ -93,13 +93,13 @@ func (u *UserRepository) CreateUser(ctx context.Context, telegramID int64, usern
 	dur = time.Since(start).Seconds()
 	cancel()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 	if dur > slowQueryThreshold.Seconds() {
 		u.logger.Warn("slow_db_query", zap.String("operation", op), zap.Float64("duration_seconds", dur))
 	}
 	if err != nil && err != sql.ErrNoRows {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 	}
 
 	u.logger.Info("user created", zap.Int64("telegram_id", telegramID))
@@ -119,8 +119,8 @@ func (u *UserRepository) GetUserByTelegramID(ctx context.Context, telegramID int
 	dur := time.Since(start).Seconds()
 	cancel()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 	if dur > slowQueryThreshold.Seconds() {
 		u.logger.Warn("slow_db_query", zap.String("operation", op), zap.Float64("duration_seconds", dur))
 	}
@@ -130,7 +130,7 @@ func (u *UserRepository) GetUserByTelegramID(ctx context.Context, telegramID int
 			u.logger.Error("context cancelled")
 			return nil, err
 		}
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		u.logger.Error("query error", zap.Error(err))
 		return nil, err
 	}
@@ -150,13 +150,13 @@ func (u *UserRepository) UpdateUserGrade(ctx context.Context, telegramID int64, 
 	dur := time.Since(start).Seconds()
 	cancel()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 	if dur > slowQueryThreshold.Seconds() {
 		u.logger.Warn("slow_db_query", zap.String("operation", op), zap.Float64("duration_seconds", dur))
 	}
 	if err != nil {
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		u.logger.Error("query error", zap.Error(err))
 		return err
 	}
@@ -186,8 +186,8 @@ func (u *UserRepository) IsAdmin(ctx context.Context, telegramID int64) (bool, e
 	dur := time.Since(start).Seconds()
 	cancel()
 
-	metrics.DBQueriesTotal.WithLabelValues(op).Inc()
-	metrics.DBQueryDuration.WithLabelValues(op).Observe(dur)
+	metrics.Default.DatabaseQueriesTotal.WithLabelValues(op).Inc()
+	metrics.Default.DatabaseQueryDuration.WithLabelValues(op).Observe(dur)
 	if dur > slowQueryThreshold.Seconds() {
 		u.logger.Warn("slow_db_query", zap.String("operation", op), zap.Float64("duration_seconds", dur))
 	}
@@ -197,7 +197,7 @@ func (u *UserRepository) IsAdmin(ctx context.Context, telegramID int64) (bool, e
 			u.logger.Error("no user found")
 			return false, err
 		}
-		metrics.DBErrorsTotal.WithLabelValues(op).Inc()
+		metrics.Default.DatabaseErrorsTotal.WithLabelValues(op).Inc()
 		u.logger.Error("query error", zap.Error(err))
 		return false, err
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,6 +5,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var Default *Metrics
+
 // Metrics хранит все кастомные метрики приложения
 type Metrics struct {
 	// Сообщения от бота
@@ -14,8 +16,9 @@ type Metrics struct {
 	MessageProcessingDuration prometheus.Histogram
 
 	// База данных
-	DatabaseQueriesTotal  prometheus.Counter
-	DatabaseQueryDuration prometheus.Histogram
+	DatabaseQueriesTotal  *prometheus.CounterVec
+	DatabaseErrorsTotal   *prometheus.CounterVec
+	DatabaseQueryDuration *prometheus.HistogramVec
 
 	// Telegram API
 	APIRequestsTotal prometheus.Counter
@@ -70,20 +73,27 @@ func NewMetrics(logger *zap.Logger) (*Metrics, error) {
 		Buckets:   prometheus.DefBuckets,
 	})
 
-	// Counter: всего запросов к БД
-	m.DatabaseQueriesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	// CounterVec: всего запросов к БД
+	m.DatabaseQueriesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bot",
 		Name:      "database_queries_total",
 		Help:      "Total number of database queries",
-	})
+	}, []string{"operation"})
 
-	// Histogram: время запросов к БД
-	m.DatabaseQueryDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	// CounterVec: ошибки БД
+	m.DatabaseErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bot",
+		Name:      "database_errors_total",
+		Help:      "Total number of database errors",
+	}, []string{"operation"})
+
+	// HistogramVec: время запросов к БД
+	m.DatabaseQueryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "bot",
 		Name:      "database_query_duration_seconds",
 		Help:      "Time spent on database queries in seconds",
 		Buckets:   prometheus.DefBuckets,
-	})
+	}, []string{"operation"})
 
 	// Counter: запросы к Telegram API
 	m.APIRequestsTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -113,6 +123,7 @@ func NewMetrics(logger *zap.Logger) (*Metrics, error) {
 		m.MessagesErrorsTotal,
 		m.MessageProcessingDuration,
 		m.DatabaseQueriesTotal,
+		m.DatabaseErrorsTotal,
 		m.DatabaseQueryDuration,
 		m.APIRequestsTotal,
 		m.ActiveUsers,
@@ -125,41 +136,11 @@ func NewMetrics(logger *zap.Logger) (*Metrics, error) {
 		}
 	}
 
+	Default = m
 	return m, nil
 }
 
 // Collector возвращает registry для интеграции с сервером
 func (m *Metrics) Collector() *prometheus.Registry {
 	return m.registry
-import "github.com/prometheus/client_golang/prometheus"
-
-var (
-	DBQueriesTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "bot_database_queries_total",
-			Help: "Total database queries",
-		},
-		[]string{"operation"},
-	)
-
-	DBErrorsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "bot_database_errors_total",
-			Help: "Total database errors",
-		},
-		[]string{"operation"},
-	)
-
-	DBQueryDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "bot_database_query_duration_seconds",
-			Help:    "Database query duration in seconds",
-			Buckets: prometheus.DefBuckets,
-		},
-		[]string{"operation"},
-	)
-)
-
-func init() {
-	prometheus.MustRegister(DBQueriesTotal, DBErrorsTotal, DBQueryDuration)
 }

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -18,7 +18,7 @@ type Server struct {
 	logger *zap.Logger
 }
 
-func NewServer(port int, db *sqlx.DB, telegram api.TelegramChecker, logger *zap.Logger) *Server {
+func NewServer(port int, db *sqlx.DB, telegram api.TelegramChecker, m *Metrics, logger *zap.Logger) *Server {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -27,7 +27,7 @@ func NewServer(port int, db *sqlx.DB, telegram api.TelegramChecker, logger *zap.
 
 	mux.HandleFunc("/health", api.NewHealthHandler(db, telegram, logger))
 
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.HandlerFor(m.Collector(), promhttp.HandlerOpts{}))
 
 	s := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),


### PR DESCRIPTION
1) DB-метрики переведены на общий registry из #16, /metrics отдаёт их через HandlerFor(m.Collector())
2) Метрики БД с label operation (create/read/update/delete): queries/errors/duration
3) Репозитории обёрнуты в timeout 10s + observe duration + errors + slow query warn >1s
4) Проверено: после /start в /metrics растёт bot_database_queries_total{operation="read"} и duration histogram