### PR TITLE
feat: add metrics instrumentation to start and callback handlers

### DIFF
--- a/internal/handlers/callbacks.go
+++ b/internal/handlers/callbacks.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/yandex-development-2-team/Go/internal/metrics"
 
 	"go.uber.org/zap"
 )
@@ -21,8 +22,25 @@ type CallbackHandler interface {
 
 func HandleCallback(router *CallbackRouter, query *tgbotapi.CallbackQuery) error {
 	start := time.Now()
+
+	metrics.Default.ActiveUsers.Inc()
+	defer metrics.Default.ActiveUsers.Dec()
+
+	metrics.Default.CallbacksReceived.Inc()
 	// Получаем и находим нужный handler в карте handlers
 	button := query.Data
+
+	var handlerErr error
+	defer func() {
+		dur := time.Since(start).Seconds()
+		metrics.Default.CallbacksProcessingDuration.Observe(dur)
+
+		router.logger.Info("handle_callback_metrics",
+			zap.String("button", button),
+			zap.Float64("duration_seconds", dur),
+			zap.Bool("success", handlerErr == nil),
+		)
+	}()
 
 	handler, ok := router.handlers[button]
 	if !ok {
@@ -38,14 +56,17 @@ func HandleCallback(router *CallbackRouter, query *tgbotapi.CallbackQuery) error
 	defer cancel()
 	err := handler.Handle(ctx, query)
 	if err != nil {
+		handlerErr = err
+		metrics.Default.MessagesErrorsTotal.Inc()
 		return err
 	}
 	/* //когда будет bot
 	_, err = bot.AnswerCallbackQuery(tgbotapi.CallbackQueryID{CallbackQueryID: query.ID, Text: "Вы нажали " + button})
 	*/
-	end := time.Now()
-	elapsed := end.Sub(start)
-	router.logger.Info("Нажата кнопка "+button, zap.String("user_id", query.ID), zap.String("callback_data", button), zap.Duration("время обработки", elapsed))
+	router.logger.Info("callback handled",
+		zap.String("button", button),
+		zap.String("callback_id", query.ID),
+	)
 	return err
 
 }

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"fmt"
+	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/yandex-development-2-team/Go/internal/metrics"
 	"go.uber.org/zap"
 )
 
@@ -13,6 +15,25 @@ func HandleStart(bot *tgbotapi.BotAPI, msg *tgbotapi.Message, logger *zap.Logger
 	if msg == nil || msg.From == nil {
 		return fmt.Errorf("invalid message from user")
 	}
+
+	start := time.Now()
+	// ActiveUsers: считаем “активных” как количество одновременно обрабатываемых запросов
+	metrics.Default.ActiveUsers.Inc()
+	defer metrics.Default.ActiveUsers.Dec()
+
+	metrics.Default.MessagesReceived.Inc()
+
+	var handlerErr error
+	defer func() {
+		dur := time.Since(start).Seconds()
+		metrics.Default.MessageProcessingDuration.Observe(dur)
+
+		logger.Info("handle_start_metrics",
+			zap.Int64("user_id", msg.From.ID),
+			zap.Float64("duration_seconds", dur),
+			zap.Bool("success", handlerErr == nil),
+		)
+	}()
 
 	user := msg.From
 
@@ -45,6 +66,9 @@ func HandleStart(bot *tgbotapi.BotAPI, msg *tgbotapi.Message, logger *zap.Logger
 
 	//обрабатываем ошибку отправки
 	if _, err := bot.Send(message); err != nil {
+		handlerErr = err
+		metrics.Default.MessagesErrorsTotal.Inc()
+
 		logger.Error("failed to send message",
 			zap.Int64("user_id", user.ID),
 			zap.Int64("chat_id", msg.Chat.ID),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,6 +27,10 @@ type Metrics struct {
 	ActiveUsers   prometheus.Gauge
 	BookingsTotal prometheus.Counter
 
+	// Callback queries
+	CallbacksReceived           prometheus.Counter
+	CallbacksProcessingDuration prometheus.Histogram
+
 	registry *prometheus.Registry
 	logger   *zap.Logger
 }
@@ -116,6 +120,19 @@ func NewMetrics(logger *zap.Logger) (*Metrics, error) {
 		Help:      "Total number of bookings made",
 	})
 
+	m.CallbacksReceived = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "bot",
+		Name:      "callbacks_received_total",
+		Help:      "Total number of callback queries received",
+	})
+
+	m.CallbacksProcessingDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "bot",
+		Name:      "callbacks_processing_duration_seconds",
+		Help:      "Time spent processing callbacks queries in seconds",
+		Buckets:   prometheus.DefBuckets,
+	})
+
 	// Регистрируем все метрики
 	collectors := []prometheus.Collector{
 		m.MessagesReceived,
@@ -128,6 +145,8 @@ func NewMetrics(logger *zap.Logger) (*Metrics, error) {
 		m.APIRequestsTotal,
 		m.ActiveUsers,
 		m.BookingsTotal,
+		m.CallbacksReceived,
+		m.CallbacksProcessingDuration,
 	}
 
 	for _, collector := range collectors {


### PR DESCRIPTION
Closed #17 

Сделано:

1) Добавил метрики в обработчики:
- HandleStart: MessagesReceived, MessageProcessingDuration.observe, ActiveUsers (inc/dec), при ошибке MessagesErrorsTotal
- HandleCallback: CallbacksReceived, CallbackProcessingDuration.observe, ActiveUsers (inc/dec), при ошибке MessagesErrorsTotal

2) Добавил лог handle_start_metrics/handle_callback_metrics с duration_seconds и success.

Проверка на скрине в ТГ
- /start увеличивает bot_messages_received_total и пишет в bot_message_processing_duration_seconds (см. /metrics).
- Ошибок от кода метрик нет.