### PR TITLE
feat: add settings endpoint and seed default settings

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -57,6 +57,10 @@ func main() {
 		log.Fatal("failed_to_run_migrations", zap.Error(err))
 	}
 
+	if err := database.EnsureDefaultSettings(context.Background(), sqlxDB); err != nil {
+		log.Fatal("failed_to_ensure_settings", zap.Error(err))
+	}
+
 	// Используем существующий UserRepository через адаптер
 	dbAdapter := repository.NewDBAdapter(db)
 	userRepo := repository.NewUserRepository(dbAdapter, log)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/yandex-development-2-team/Go/internal/models"
+	"go.uber.org/zap"
+)
+
+func NewSettingsHandler(db *sqlx.DB, logger *zap.Logger) http.HandlerFunc {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+		var raw struct {
+			Notifications []byte `json:"notifications"`
+			Booking       []byte `json:"booking"`
+			General       []byte `json:"general"`
+		}
+
+		if err := db.GetContext(r.Context(), &raw, `
+SELECT notifications, booking, general
+FROM settings
+WHERE id = 1
+`); err != nil {
+			logger.Error("failed_to_get_settings", zap.Error(err))
+			http.Error(w, "failed to get settings", http.StatusInternalServerError)
+			return
+		}
+
+		var resp models.Settings
+		if err := json.Unmarshal(raw.Notifications, &resp.Notifications); err != nil {
+			http.Error(w, "invalid notifications json", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(raw.Booking, &resp.Booking); err != nil {
+			http.Error(w, "invalid booking json", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(raw.General, &resp.General); err != nil {
+			http.Error(w, "invalid general json", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -1,0 +1,33 @@
+package database
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func EnsureDefaultSettings(ctx context.Context, db *sqlx.DB) error {
+	_, err := db.ExecContext(ctx, `
+INSERT INTO settings (id, notifications, booking, general)
+VALUES (
+  1,
+  '{
+    "telegram_bot_token": "",
+    "auto_reminders": false,
+    "reminder_hours_before": 24
+  }'::jsonb,
+  '{
+    "max_slots_per_event": 10,
+    "allow_overbooking": false,
+    "cancellation_allowed_hours": 24
+  }'::jsonb,
+  '{
+    "site_name": "Yandex Bot",
+    "contact_email": "support@example.com",
+    "contact_phone": ""
+  }'::jsonb
+)
+ON CONFLICT (id) DO NOTHING;
+`)
+	return err
+}

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/yandex-development-2-team/Go/internal/metrics"
 	"go.uber.org/zap"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -29,6 +29,8 @@ func NewServer(port int, db *sqlx.DB, telegram api.TelegramChecker, m *Metrics, 
 
 	mux.Handle("/metrics", promhttp.HandlerFor(m.Collector(), promhttp.HandlerOpts{}))
 
+	mux.HandleFunc("/api/v1/settings", api.NewSettingsHandler(db, logger))
+
 	s := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           mux,

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -1,0 +1,25 @@
+package models
+
+type Settings struct {
+	Notifications NotificationsSettings `json:"notifications"`
+	Booking       BookingSettings       `json:"booking"`
+	General       GeneralSettings       `json:"general"`
+}
+
+type NotificationsSettings struct {
+	TelegramBotToken    string `json:"telegram_bot_token"`
+	AutoReminders       bool   `json:"auto_reminders"`
+	ReminderHoursBefore int    `json:"reminder_hours_before"`
+}
+
+type BookingSettings struct {
+	MaxSlotsPerEvent         int  `json:"max_slots_per_event"`
+	AllowOverbooking         bool `json:"allow_overbooking"`
+	CancellationAllowedHours int  `json:"cancellation_allowed_hours"`
+}
+
+type GeneralSettings struct {
+	SiteName     string `json:"site_name"`
+	ContactEmail string `json:"contact_email"`
+	ContactPhone string `json:"contact_phone"`
+}

--- a/migrations/20260313092232_create_settings_table.sql
+++ b/migrations/20260313092232_create_settings_table.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS settings (
+    id SMALLINT PRIMARY KEY,
+    notifications JSONB NOT NULL,
+    booking JSONB NOT NULL,
+    general JSONB NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO settings (id, notifications, booking, general)
+VALUES (
+           1,
+           '{
+             "telegram_bot_token": "",
+             "auto_reminders": false,
+             "reminder_hours_before": 24
+           }'::jsonb,
+           '{
+             "max_slots_per_event": 10,
+             "allow_overbooking": false,
+             "cancellation_allowed_hours": 24
+           }'::jsonb,
+           '{
+             "site_name": "Yandex Bot",
+             "contact_email": "support@example.com",
+             "contact_phone": ""
+           }'::jsonb
+       )
+ON CONFLICT (id) DO NOTHING;
+
+-- +goose Down
+DROP TABLE IF EXISTS settings;


### PR DESCRIPTION
Closed #55 
Сделано:
1) Добавлена таблица settings и сидирование дефолтов (id=1).
2) При старте выполняется create if not exists (ensure записи).
3) Реализован GET /api/v1/settings, возвращает Settings schema.
4) Проверено: миграция применяется, endpoint отдаёт корректный JSON.